### PR TITLE
remove p2 support

### DIFF
--- a/consistency/pom.xml
+++ b/consistency/pom.xml
@@ -95,17 +95,17 @@
                     <dependency>
                         <groupId>tools.vitruv</groupId>
                         <artifactId>tools.vitruv.dsls.reactions.language</artifactId>
-                        <version>3.1.0</version>
+                        <version>${vitruv-change.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>tools.vitruv</groupId>
                         <artifactId>tools.vitruv.dsls.reactions.runtime</artifactId>
-                        <version>3.1.0</version>
+                        <version>${vitruv-change.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>tools.vitruv</groupId>
                         <artifactId>tools.vitruv.dsls.common</artifactId>
-                        <version>3.1.0</version>
+                        <version>${vitruv-change.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>parent</artifactId>
-    <version>3.0.6</version>
+    <version>3.0.7</version>
   </parent>
 
   <!-- Project Information -->

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,12 @@
     <module>consistency</module>
   </modules>
 
+  <properties>
+    <vitruv-change.version>3.1.0</vitruv-change.version>
+    <vitruv-dsls.version>3.1.0</vitruv-dsls.version>
+    <vitruv-framework.version>3.1.0</vitruv-framework.version>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -43,42 +49,42 @@
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.atomic</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.composite</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.interaction</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.propagation</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.testutils.integration</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.dsls.reactions.runtime</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-dsls.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.framework.views</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-framework.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.framework.vsum</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-framework.version}</version>
       </dependency>
 
       <!-- external dependencies-->

--- a/pom.xml
+++ b/pom.xml
@@ -34,15 +34,6 @@
     <vitruv-framework.version>3.1.0</vitruv-framework.version>
   </properties>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.openntf.maven</groupId>
-        <artifactId>p2-layout-resolver</artifactId>
-      </plugin>
-    </plugins>
-  </build>
-
   <dependencyManagement>
     <dependencies>
       <!-- Vitruvius dependencies -->


### PR DESCRIPTION
remove p2 support, as p2 dependencies will be included in the deployed packages of Vitruvius

depends on https://github.com/vitruv-tools/Vitruv-Change/pull/133, https://github.com/vitruv-tools/Vitruv-DSLs/pull/164, https://github.com/vitruv-tools/Vitruv/pull/662