### PR TITLE
Update to Vitruv 3.1.2

### DIFF
--- a/consistency/pom.xml
+++ b/consistency/pom.xml
@@ -95,17 +95,17 @@
                     <dependency>
                         <groupId>tools.vitruv</groupId>
                         <artifactId>tools.vitruv.dsls.reactions.language</artifactId>
-                        <version>3.1.0</version>
+                        <version>${vitruv.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>tools.vitruv</groupId>
                         <artifactId>tools.vitruv.dsls.reactions.runtime</artifactId>
-                        <version>3.1.0</version>
+                        <version>${vitruv.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>tools.vitruv</groupId>
                         <artifactId>tools.vitruv.dsls.common</artifactId>
-                        <version>3.1.0</version>
+                        <version>${vitruv.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>parent</artifactId>
-    <version>3.0.6</version>
+    <version>3.0.7</version>
   </parent>
 
   <!-- Project Information -->

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
     <module>consistency</module>
   </modules>
 
+  <properties>
+    <vitruv.version>3.1.2</vitruv.version>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -43,42 +47,42 @@
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.atomic</artifactId>
-        <version>3.1.2</version>
+        <version>${vitruv.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.composite</artifactId>
-        <version>3.1.2</version>
+        <version>${vitruv.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.interaction</artifactId>
-        <version>3.1.2</version>
+        <version>${vitruv.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.propagation</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.testutils.integration</artifactId>
-        <version>3.1.2</version>
+        <version>${vitruv.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.dsls.reactions.runtime</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.framework.views</artifactId>
-        <version>3.1.2</version>
+        <version>${vitruv.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.framework.vsum</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv.version}</version>
       </dependency>
 
       <!-- external dependencies-->

--- a/pom.xml
+++ b/pom.xml
@@ -32,15 +32,6 @@
     <vitruv.version>3.1.2</vitruv.version>
   </properties>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.openntf.maven</groupId>
-        <artifactId>p2-layout-resolver</artifactId>
-      </plugin>
-    </plugins>
-  </build>
-
   <dependencyManagement>
     <dependencies>
       <!-- Vitruvius dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.atomic</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.2</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>


### PR DESCRIPTION
Bumps various Vitruvius dependencies.

Closes #10 #11 #12 #13 #14 

Signed-off-by: dependabot[bot] <support@github.com>