### PR TITLE
Add tests to verify annotations are available inside reactions

### DIFF
--- a/consistency/src/main/reactions/tools/vitruv/methodologisttemplate/consistency/templateReactions.reactions
+++ b/consistency/src/main/reactions/tools/vitruv/methodologisttemplate/consistency/templateReactions.reactions
@@ -51,6 +51,7 @@ routine createAndInsertEntity(model::System system, model::Component component) 
     val entity = new model2::Entity
   }
 	update {
+    println("createAndInsertEntity called with component.name=" + component.name)
     entity.name = component.name
     mRoot.entities.add(entity)
 		addCorrespondenceBetween(component, entity)
@@ -64,13 +65,16 @@ reaction ComponentRenamed {
 	call renameEntity(affectedEObject)
 }
 
+// Only propagates the rename when the committing author is "methodologist".
 routine renameEntity(model::Component component) {
 	match {
     val entity = retrieve model2::Entity corresponding to component
 	}
-  // we can omit blocks like the update block if we do not need them
 	update {
-    entity.name = component.name
+	    println(changeAnnotations.getAnnotation(tools.vitruv.methodologisttemplate.model.Author))
+		if (changeAnnotations.getAnnotation(tools.vitruv.methodologisttemplate.model.Author).map[name == "methodologist"].orElse(false)) {
+    	entity.name = component.name
+    }
 	}
 }
 

--- a/consistency/src/main/reactions/tools/vitruv/methodologisttemplate/consistency/templateReactions.reactions
+++ b/consistency/src/main/reactions/tools/vitruv/methodologisttemplate/consistency/templateReactions.reactions
@@ -51,8 +51,7 @@ routine createAndInsertEntity(model::System system, model::Component component) 
     val entity = new model2::Entity
   }
 	update {
-    println("createAndInsertEntity called with component.name=" + component.name)
-    entity.name = component.name
+entity.name = component.name
     mRoot.entities.add(entity)
 		addCorrespondenceBetween(component, entity)
 	}

--- a/model/src/main/java/tools/vitruv/methodologisttemplate/model/Author.java
+++ b/model/src/main/java/tools/vitruv/methodologisttemplate/model/Author.java
@@ -1,0 +1,5 @@
+package tools.vitruv.methodologisttemplate.model;
+
+/** Annotation identifying who committed a change to a view. */
+public record Author(String name) {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </modules>
 
   <properties>
-    <vitruv.version>3.2.3</vitruv.version>
+    <vitruv.version>3.2.4-SNAPSHOT</vitruv.version>
   </properties>
 
   <dependencyManagement>

--- a/vsum/src/main/java/tools/vitruv/methodologisttemplate/vsum/VSUMExample.java
+++ b/vsum/src/main/java/tools/vitruv/methodologisttemplate/vsum/VSUMExample.java
@@ -25,11 +25,15 @@ public class VSUMExample {
   }
 
   private static VirtualModel createDefaultVirtualModel() {
-    return new VirtualModelBuilder()
-        .withStorageFolder(Path.of("vsumexample"))
-        .withUserInteractorForResultProvider(new TestUserInteraction.ResultProvider(new TestUserInteraction()))
-        .withChangePropagationSpecifications(new Model2Model2ChangePropagationSpecification())
-        .buildAndInitialize();
+    try {
+      return new VirtualModelBuilder()
+              .withStorageFolder(Path.of("vsumexample"))
+              .withUserInteractorForResultProvider(new TestUserInteraction.ResultProvider(new TestUserInteraction()))
+              .withChangePropagationSpecifications(new Model2Model2ChangePropagationSpecification())
+              .buildAndInitialize();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private static View getDefaultView(VirtualModel vsum) {

--- a/vsum/src/test/java/tools/vitruv/methodologisttemplate/vsum/VSUMExampleTest.java
+++ b/vsum/src/test/java/tools/vitruv/methodologisttemplate/vsum/VSUMExampleTest.java
@@ -109,7 +109,11 @@ public class VSUMExampleTest {
     VirtualModel vsum = createDefaultVirtualModel(tempDir);
     addSystem(vsum, tempDir);
     addComponent(vsum);
-    CommittableView view = getDefaultView(vsum, List.of(System.class)).withChangeDerivingTrait();
+    // ChangeRecordingView records the setName() call as a ReplaceSingleValuedEAttribute, ensuring
+    // ComponentRenamed fires. ChangeDerivingView (state diff) would produce DELETE+CREATE for a
+    // rename because EMFCompare proximity matching fails when the old and new names are too
+    // dissimilar, which bypasses the annotation guard entirely.
+    CommittableView view = getDefaultView(vsum, List.of(System.class)).withChangeRecordingTrait();
     view.getRootObjects(System.class).iterator().next().getComponents().get(0).setName(newName);
     view.setAnnotation(Author.class, new Author("methodologist"));
     view.commitChanges();
@@ -128,7 +132,8 @@ public class VSUMExampleTest {
     VirtualModel vsum = createDefaultVirtualModel(tempDir);
     addSystem(vsum, tempDir);
     addComponent(vsum);
-    CommittableView view = getDefaultView(vsum, List.of(System.class)).withChangeDerivingTrait();
+    // See renameComponent for why ChangeRecordingView is used here instead of ChangeDerivingView.
+    CommittableView view = getDefaultView(vsum, List.of(System.class)).withChangeRecordingTrait();
     view.getRootObjects(System.class).iterator().next().getComponents().get(0).setName(newName);
     view.setAnnotation(Author.class, new Author("methodologist"));
     view.commitChanges();
@@ -145,7 +150,8 @@ public class VSUMExampleTest {
     VirtualModel vsum = createDefaultVirtualModel(tempDir);
     addSystem(vsum, tempDir);
     addComponent(vsum);
-    CommittableView view = getDefaultView(vsum, List.of(System.class)).withChangeDerivingTrait();
+    // See renameComponent for why ChangeRecordingView is used here instead of ChangeDerivingView.
+    CommittableView view = getDefaultView(vsum, List.of(System.class)).withChangeRecordingTrait();
     view.getRootObjects(System.class).iterator().next().getComponents().get(0).setName(newName);
     // no Author annotation — rename reaction precondition is not satisfied
     view.commitChanges();

--- a/vsum/src/test/java/tools/vitruv/methodologisttemplate/vsum/VSUMExampleTest.java
+++ b/vsum/src/test/java/tools/vitruv/methodologisttemplate/vsum/VSUMExampleTest.java
@@ -23,6 +23,7 @@ import tools.vitruv.framework.views.ViewTypeFactory;
 import tools.vitruv.framework.vsum.VirtualModel;
 import tools.vitruv.framework.vsum.VirtualModelBuilder;
 import tools.vitruv.framework.vsum.internal.InternalVirtualModel;
+import tools.vitruv.methodologisttemplate.model.Author;
 import tools.vitruv.methodologisttemplate.model.model.ModelFactory;
 import tools.vitruv.methodologisttemplate.model.model.System;
 import tools.vitruv.methodologisttemplate.model.model2.Root;
@@ -108,17 +109,50 @@ public class VSUMExampleTest {
     VirtualModel vsum = createDefaultVirtualModel(tempDir);
     addSystem(vsum, tempDir);
     addComponent(vsum);
-    modifyView(getDefaultView(vsum, List.of(System.class)).withChangeDerivingTrait(), (CommittableView v) -> {
-      // change the name of the component
-      v.getRootObjects(System.class).iterator().next().getComponents().get(0).setName(newName);
-    });
+    CommittableView view = getDefaultView(vsum, List.of(System.class)).withChangeDerivingTrait();
+    view.getRootObjects(System.class).iterator().next().getComponents().get(0).setName(newName);
+    view.setAnnotation(Author.class, new Author("methodologist"));
+    view.commitChanges();
     Assertions.assertTrue(assertView(getDefaultView(vsum, List.of(System.class, Root.class)), (View v) -> {
-      // assert that the renaming worked on the component as well as the corresponding
-      // entity
+      // assert that the renaming worked on the component as well as the corresponding entity
       return v.getRootObjects(System.class).iterator().next()
           .getComponents().get(0).getName().equals(newName)
           && v.getRootObjects(Root.class).iterator().next()
               .getEntities().get(0).getName().equals(newName);
+    }));
+  }
+
+  @Test
+  void renameComponentWithAuthorPropagates(@TempDir Path tempDir) {
+    final String newName = "authorizedName";
+    VirtualModel vsum = createDefaultVirtualModel(tempDir);
+    addSystem(vsum, tempDir);
+    addComponent(vsum);
+    CommittableView view = getDefaultView(vsum, List.of(System.class)).withChangeDerivingTrait();
+    view.getRootObjects(System.class).iterator().next().getComponents().get(0).setName(newName);
+    view.setAnnotation(Author.class, new Author("methodologist"));
+    view.commitChanges();
+    Assertions.assertTrue(assertView(getDefaultView(vsum, List.of(System.class, Root.class)), (View v) -> {
+      return v.getRootObjects(Root.class).iterator().next()
+          .getEntities().get(0).getName().equals(newName);
+    }));
+  }
+
+  @Test
+  void renameComponentWithoutAuthorDoesNotPropagate(@TempDir Path tempDir) {
+    final String originalName = "specialname";
+    final String newName = "unauthorizedName";
+    VirtualModel vsum = createDefaultVirtualModel(tempDir);
+    addSystem(vsum, tempDir);
+    addComponent(vsum);
+    CommittableView view = getDefaultView(vsum, List.of(System.class)).withChangeDerivingTrait();
+    view.getRootObjects(System.class).iterator().next().getComponents().get(0).setName(newName);
+    // no Author annotation — rename reaction precondition is not satisfied
+    view.commitChanges();
+    Assertions.assertTrue(assertView(getDefaultView(vsum, List.of(System.class, Root.class)), (View v) -> {
+      // model2 entity name should still be the original name
+      return v.getRootObjects(Root.class).iterator().next()
+          .getEntities().get(0).getName().equals(originalName);
     }));
   }
 
@@ -204,13 +238,17 @@ public class VSUMExampleTest {
   }
 
   private InternalVirtualModel createDefaultVirtualModel(Path projectPath) {
-    InternalVirtualModel model = new VirtualModelBuilder()
-        .withStorageFolder(projectPath)
-        .withUserInteractorForResultProvider(new TestUserInteraction.ResultProvider(new TestUserInteraction()))
-        .withChangePropagationSpecifications(new Model2Model2ChangePropagationSpecification())
-        .buildAndInitialize();
-    model.setChangePropagationMode(ChangePropagationMode.TRANSITIVE_CYCLIC);
-    return model;
+    try {
+      InternalVirtualModel model = new VirtualModelBuilder()
+              .withStorageFolder(projectPath)
+              .withUserInteractorForResultProvider(new TestUserInteraction.ResultProvider(new TestUserInteraction()))
+              .withChangePropagationSpecifications(new Model2Model2ChangePropagationSpecification())
+              .buildAndInitialize();
+      model.setChangePropagationMode(ChangePropagationMode.TRANSITIVE_CYCLIC);
+      return model;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
   // See https://github.com/vitruv-tools/Vitruv/issues/717 for more information


### PR DESCRIPTION
Depends on https://github.com/vitruv-tools/Vitruv-Change/pull/382 and https://github.com/vitruv-tools/Vitruv-DSLs/pull/532 and https://github.com/vitruv-tools/Vitruv/pull/858. Currently, the renameComponentWithoutAuthorDoesNotPropagate test fails for an unknown reason. Will continue to investigate.